### PR TITLE
add notes about using your own server to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ You can log into the [FusionAuth admin UI](http://localhost:9011/admin) and look
 
 The `complete-application` directory contains a minimal React app configured to authenticate with locally running FusionAuth.
 
+* If you want to use your own server to perform the OAuth token exchange, update the `serverUrl` property of your [config object](https://github.com/FusionAuth/fusionauth-quickstart-javascript-react-web/blob/main/complete-application/src/config.js). See [example server implementation](https://github.com/FusionAuth/fusionauth-javascript-sdk-express).
+
 Install dependencies and run the React app with:
 ```
 cd complete-application


### PR DESCRIPTION
Issue #9 -- Adding a section to README explaining how to configure with your own server. Keeping the documentation up to date as we consolidate our example repos. This repo will become the main example implementation for the React SDK.