### PR TITLE
6 Add Redirect Handling to Log In or Create New Account CTA

### DIFF
--- a/complete-application/src/index.css
+++ b/complete-application/src/index.css
@@ -92,6 +92,14 @@ body {
   text-decoration-line: none;
 }
 
+.button-redirect {
+  background: none;
+  border: none;
+  font-size: 18px;
+  font-family: sans-serif;
+  color: #096324;
+}
+
 .column-container {
   display: flex;
   flex-direction: row;

--- a/complete-application/src/pages/HomePage.js
+++ b/complete-application/src/pages/HomePage.js
@@ -6,7 +6,7 @@ import {useEffect} from "react";
 export default function HomePage() {
   const navigate = useNavigate();
 
-  const {isAuthenticated, isLoading} = useFusionAuth();
+  const {isAuthenticated, isLoading, login, register} = useFusionAuth();
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -23,7 +23,16 @@ export default function HomePage() {
       <div className="content-container">
         <div style={{marginBottom: '100px'}}>
           <h1>Welcome to Changebank</h1>
-          <p>To get started, <a style={{cursor: "pointer"}}>log in or create a new account</a>.</p>
+          <p>
+            To get started,
+            <button className="button-redirect" style={{ cursor: "pointer" }} onClick={() => login()}>
+              log in
+            </button>
+            or
+            <button className="button-redirect" style={{ cursor: "pointer" }} onClick={() => register()}>
+              create a new account.
+            </button>
+          </p>
         </div>
       </div>
 


### PR DESCRIPTION
### **What is this PR and why do we need it?**

Adds onClick event to "log in" to redirect users to log in flow
Adds onClick event to "create a new account" to redirect users to register flow

We are switching from using an anchor to using a button here for accessibility purposes. There should be no visible changes to the UI and clicking the log in or create a new account buttons on the home page should respectively redirect to log in and register flow.

https://github.com/FusionAuth/fusionauth-quickstart-javascript-react-web/issues/6

Pre-Merge Checklist (if applicable)

- [ ] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.