### PR TITLE
26 Update Properties Used in Menu Bar and Make Change Page

### DIFF
--- a/complete-application/src/components/MenuBar.tsx
+++ b/complete-application/src/components/MenuBar.tsx
@@ -2,12 +2,12 @@ import {useFusionAuth} from "@fusionauth/react-sdk";
 import {NavLink} from "react-router-dom";
 
 export default function MenuBar() {
-  const {isAuthenticated} = useFusionAuth();
+  const {isLoggedIn} = useFusionAuth();
 
   return (
     <div id="menu-bar" className="menu-bar">
       {
-        isAuthenticated ? (
+        isLoggedIn ? (
           <>
             <NavLink to="/make-change" className="menu-link" activeClassName="active">Make Change</NavLink>
             <NavLink to="/account" className="menu-link" activeClassName="active">Account</NavLink>

--- a/complete-application/src/pages/MakeChangePage.tsx
+++ b/complete-application/src/pages/MakeChangePage.tsx
@@ -2,7 +2,7 @@ import {useFusionAuth} from "@fusionauth/react-sdk";
 import {useEffect, useState} from "react";
 import {useNavigate} from "react-router-dom";
 
-let dollarUS = Intl.NumberFormat("en-US", {
+const dollarUS = Intl.NumberFormat("en-US", {
   style: "currency",
   currency: "USD",
   useGrouping: false,
@@ -14,13 +14,13 @@ export default function MakeChangePage() {
 
   const navigate = useNavigate();
 
-  const {isAuthenticated, isLoading} = useFusionAuth();
+  const {isLoggedIn, isFetchingUserInfo} = useFusionAuth();
 
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (!isLoggedIn) {
       navigate('/');
     }
-  }, [isAuthenticated, navigate]);
+  }, [isLoggedIn, navigate]);
 
   const makeChange = (e) => {
     e.stopPropagation();
@@ -32,7 +32,7 @@ export default function MakeChangePage() {
     setChange({total, nickels, pennies})
   };
 
-  if (!isAuthenticated || isLoading) {
+  if (!isLoggedIn || isFetchingUserInfo) {
     return null;
   }
 


### PR DESCRIPTION
### What is this PR and why do we need it?
This PR updates the usage of the old `isAuthenticated` and `isLoading` properties to reflect the `v2.0` context properties as defined [here](https://github.com/FusionAuth/fusionauth-javascript-sdk/blob/main/packages/sdk-react/docs/interfaces/FusionAuthProviderContext.FusionAuthProviderContext.md#isfetchinguserinfo)

**To Test within UI**
Log In as a valid registered change bank user
Click on the Make Change link within the menu bar
Ensure Make Change UI appears and functions as expected
Ensure Menu Bar clearly displays which page is being viewed and switches to each view appropriately

**Developer Test**
Run the following command and ensure that there are no build errors related to the use of `isAuthenticated` or `isLoading` properties
Ensure cookies are being set and removed as expected based on auth state

https://github.com/FusionAuth/fusionauth-quickstart-javascript-react-web/issues/26

