### PR TITLE
30 Remove activeClassName Property in MenuBar

### DIFF
--- a/complete-application/src/components/MenuBar.tsx
+++ b/complete-application/src/components/MenuBar.tsx
@@ -9,8 +9,8 @@ export default function MenuBar() {
       {
         isLoggedIn ? (
           <>
-            <NavLink to="/make-change" className="menu-link" activeClassName="active">Make Change</NavLink>
-            <NavLink to="/account" className="menu-link" activeClassName="active">Account</NavLink>
+            <NavLink to="/make-change" className="menu-link">Make Change</NavLink>
+            <NavLink to="/account" className="menu-link">Account</NavLink>
           </>
         ) : (
           <>


### PR DESCRIPTION
### What is this PR and why do we need it?
This PR removes the `activeClassName` property within the `MenuBar.tsx` file.
Console and build errors were occurring in relation to the usage of the `activeClassName` property which does not exist within the project. 

**To Test:**
Log in as a valid registered Change Bank user
Click on the menu bar links and observe the console dev tools for any error responses related to `activeClassName`

**For Developers:**
Run the `npm run build` command and ensure there is no errors related to `activeClassName`

https://github.com/FusionAuth/fusionauth-quickstart-javascript-react-web/issues/30

Pre-Merge Checklist (if applicable)
- [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.