### PR TITLE
38 Build Out Example postLogoutRedirectUri Routing

### DIFF
--- a/complete-application/src/App.tsx
+++ b/complete-application/src/App.tsx
@@ -23,6 +23,7 @@ function App() {
       </div>
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/logged-out" element={<HomePage />} />
           <Route path="/account" element={<AccountPage />} />
           <Route path="/make-change" element={<MakeChangePage />} />
           <Route path="*" element={<Navigate to="/" />} />

--- a/complete-application/src/main.tsx
+++ b/complete-application/src/main.tsx
@@ -11,6 +11,7 @@ import {
 const config: FusionAuthProviderConfig = {
   clientId: "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e",
   redirectUri: "http://localhost:3000",
+  postLogoutRedirectUri: "http://localhost:3000/logged-out",
   serverUrl: "http://localhost:9011",
   shouldAutoFetchUserInfo: true,
   shouldAutoRefresh: true,

--- a/kickstart/kickstart.json
+++ b/kickstart/kickstart.json
@@ -2,6 +2,7 @@
   "variables": {
     "allowedOrigin": "http://localhost:3000",
     "authorizedRedirectURL": "http://localhost:3000",
+    "authorizedPostLogoutURL": "http://localhost:3000/logged-out",
     "authorizedOriginURL": "http://localhost:3000",
     "logoutURL": "http://localhost:3000",
     "applicationId": "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e",
@@ -90,6 +91,7 @@
           "name": "Example app",
           "oauthConfiguration": {
             "authorizedRedirectURLs": [
+              "#{authorizedPostLogoutURL}",
               "#{authorizedRedirectURL}"
             ],
             "authorizedOriginURLs": [


### PR DESCRIPTION
### What is this PR and why do we need it?
The current implementation of `postLogoutRedirectUri` could benefit from a more illustrative example for users. This PR adds routing that demonstrates the behavior expected when the `postLogoutRedirectUri `is defined vs undefined.

https://github.com/FusionAuth/fusionauth-quickstart-javascript-react-web/issues/38

To Test:
1. Login and Logout in the quickstart application observing the url on logout, this should redirect to` /logged-out`.
2. Comment out the `postLogoutRedirectUri` in the `main.tsx` file and restart the server
3. Repeat step one and ensure the redirect on log out goes to `/` as defined in the `redirectUri`

Pre-Merge Checklist (if applicable)
[x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.